### PR TITLE
filePath argument for yaml.dumpFile => file

### DIFF
--- a/functionSignatures.json
+++ b/functionSignatures.json
@@ -1,70 +1,80 @@
 {
-  "yaml.dump": {
-	  "inputs": [
-		{
-			"name": "data",
-			"kind": "required",
-			"purpose": "Data to be converted to YAML"
-		},
-		{
-			"name": "style",
-			"kind": "ordered",
-			"type": "choices={'block', 'flow', 'auto'}",
-			"purpose": "YAML style for sequences and mappings"
-		}
-	  ]
-  },
-  "yaml.dumpFile": {
-	  "inputs": [
-        {
-			"name": "filePath",
-			"kind": "required",
-			"type": "string",
-			"purpose": "Path to new YAML file"
-		},
-		{
-			"name": "data",
-			"kind": "required",
-			"purpose": "Data to be converted to YAML"
-		},
-		{
-			"name": "style",
-			"kind": "ordered",
-			"type": "choices={'block', 'flow', 'auto'}",
-			"purpose": "YAML style for sequences and mappings"
-		}
-	  ]
-  },
-  "yaml.load":{
-	  "inputs": [
-		{
-			"name": "s", 
-			"kind": "required", 
-			"type": "string",
-			"purpose": "String with YAML data"
-		},
-		{
-			"name": "ConvertToArray", 
-			"kind": "namevalue", 
-			"type": ["logical", "scalar"],
-			"purpose": "Try to convert sequences to non-cell arrays."
-		}
-	  ]
-  },
-  "yaml.loadFile": {
-	"inputs": [
-        {
-			"name": "filePath", 
-			"kind": "required", 
-			"type": ["file=*.yaml,*.yml,*.txt"], 
-			"purpose": "Path to YAML file"
-		},
-		{
-			"name": "ConvertToArray", 
-			"kind": "namevalue", 
-			"type": ["logical", "scalar"],
-			"purpose": "Try to convert sequences to non-cell arrays."
-		}
-    ]
-  }
+	"yaml.dump": {
+		"inputs": [
+			{
+				"name": "data",
+				"kind": "required",
+				"purpose": "Data to be converted to YAML"
+			},
+			{
+				"name": "style",
+				"kind": "ordered",
+				"type": "choices={'block', 'flow', 'auto'}",
+				"purpose": "YAML style for sequences and mappings"
+			}
+		]
+	},
+	"yaml.dumpFile": {
+		"inputs": [
+			{
+				"name": "filePath",
+				"kind": "required",
+				"type": [
+					"file=*.yaml,*.yml,*.txt"
+				],
+				"purpose": "Path to new YAML file"
+			},
+			{
+				"name": "data",
+				"kind": "required",
+				"purpose": "Data to be converted to YAML"
+			},
+			{
+				"name": "style",
+				"kind": "ordered",
+				"type": "choices={'block', 'flow', 'auto'}",
+				"purpose": "YAML style for sequences and mappings"
+			}
+		]
+	},
+	"yaml.load": {
+		"inputs": [
+			{
+				"name": "s",
+				"kind": "required",
+				"type": "string",
+				"purpose": "String with YAML data"
+			},
+			{
+				"name": "ConvertToArray",
+				"kind": "namevalue",
+				"type": [
+					"logical",
+					"scalar"
+				],
+				"purpose": "Try to convert sequences to non-cell arrays."
+			}
+		]
+	},
+	"yaml.loadFile": {
+		"inputs": [
+			{
+				"name": "filePath",
+				"kind": "required",
+				"type": [
+					"file=*.yaml,*.yml,*.txt"
+				],
+				"purpose": "Path to YAML file"
+			},
+			{
+				"name": "ConvertToArray",
+				"kind": "namevalue",
+				"type": [
+					"logical",
+					"scalar"
+				],
+				"purpose": "Try to convert sequences to non-cell arrays."
+			}
+		]
+	}
 }

--- a/functionSignatures.json
+++ b/functionSignatures.json
@@ -1,80 +1,70 @@
 {
-	"yaml.dump": {
-		"inputs": [
-			{
-				"name": "data",
-				"kind": "required",
-				"purpose": "Data to be converted to YAML"
-			},
-			{
-				"name": "style",
-				"kind": "ordered",
-				"type": "choices={'block', 'flow', 'auto'}",
-				"purpose": "YAML style for sequences and mappings"
-			}
-		]
-	},
-	"yaml.dumpFile": {
-		"inputs": [
-			{
-				"name": "filePath",
-				"kind": "required",
-				"type": [
-					"file=*.yaml,*.yml,*.txt"
-				],
-				"purpose": "Path to new YAML file"
-			},
-			{
-				"name": "data",
-				"kind": "required",
-				"purpose": "Data to be converted to YAML"
-			},
-			{
-				"name": "style",
-				"kind": "ordered",
-				"type": "choices={'block', 'flow', 'auto'}",
-				"purpose": "YAML style for sequences and mappings"
-			}
-		]
-	},
-	"yaml.load": {
-		"inputs": [
-			{
-				"name": "s",
-				"kind": "required",
-				"type": "string",
-				"purpose": "String with YAML data"
-			},
-			{
-				"name": "ConvertToArray",
-				"kind": "namevalue",
-				"type": [
-					"logical",
-					"scalar"
-				],
-				"purpose": "Try to convert sequences to non-cell arrays."
-			}
-		]
-	},
-	"yaml.loadFile": {
-		"inputs": [
-			{
-				"name": "filePath",
-				"kind": "required",
-				"type": [
-					"file=*.yaml,*.yml,*.txt"
-				],
-				"purpose": "Path to YAML file"
-			},
-			{
-				"name": "ConvertToArray",
-				"kind": "namevalue",
-				"type": [
-					"logical",
-					"scalar"
-				],
-				"purpose": "Try to convert sequences to non-cell arrays."
-			}
-		]
-	}
+  "yaml.dump": {
+	  "inputs": [
+		{
+			"name": "data",
+			"kind": "required",
+			"purpose": "Data to be converted to YAML"
+		},
+		{
+			"name": "style",
+			"kind": "ordered",
+			"type": "choices={'block', 'flow', 'auto'}",
+			"purpose": "YAML style for sequences and mappings"
+		}
+	  ]
+  },
+  "yaml.dumpFile": {
+	  "inputs": [
+        {
+			"name": "filePath",
+			"kind": "required",
+			"type": "string",
+			"purpose": "Path to new YAML file"
+		},
+		{
+			"name": "data",
+			"kind": "required",
+			"purpose": "Data to be converted to YAML"
+		},
+		{
+			"name": "style",
+			"kind": "ordered",
+			"type": "choices={'block', 'flow', 'auto'}",
+			"purpose": "YAML style for sequences and mappings"
+		}
+	  ]
+  },
+  "yaml.load":{
+	  "inputs": [
+		{
+			"name": "s", 
+			"kind": "required", 
+			"type": "string",
+			"purpose": "String with YAML data"
+		},
+		{
+			"name": "ConvertToArray", 
+			"kind": "namevalue", 
+			"type": ["logical", "scalar"],
+			"purpose": "Try to convert sequences to non-cell arrays."
+		}
+	  ]
+  },
+  "yaml.loadFile": {
+	"inputs": [
+        {
+			"name": "filePath", 
+			"kind": "required", 
+			"type": ["file=*.yaml,*.yml,*.txt"], 
+			"purpose": "Path to YAML file"
+		},
+		{
+			"name": "ConvertToArray", 
+			"kind": "namevalue", 
+			"type": ["logical", "scalar"],
+			"purpose": "Try to convert sequences to non-cell arrays."
+		}
+    ]
+  }
 }

--- a/functionSignatures.json
+++ b/functionSignatures.json
@@ -19,7 +19,7 @@
         {
 			"name": "filePath",
 			"kind": "required",
-			"type": "string",
+			"type": ["file=*.yaml,*.yml,*.txt"],
 			"purpose": "Path to new YAML file"
 		},
 		{


### PR DESCRIPTION
Changed the function signature spec for `yaml.dumpFile` to suggest `.yaml` filepaths for the `filePath` argument. This doesn't prevent the user from specifying a filepath that doesn't exist, but is nice when you're overwriting a file since it will autocomplete for you. Also, my editor decided to format the entire yaml file -- hence the fictive edits on each line.