### PR TITLE
Add option to convert YAML string to MATLAB char

### DIFF
--- a/+yaml/load.m
+++ b/+yaml/load.m
@@ -3,6 +3,9 @@ function result = load(s, options)
 %   DATA = YAML.LOAD(STR) parses a YAML string STR and converts it to
 %   appropriate data types DATA.
 %
+%   DATA = YAML.LOAD(STR, "StringToChar", true) converts YAML String to
+%   MATLAB char instead of MATLAB string.
+%
 %   DATA = YAML.LOAD(STR, "ConvertToArray", true) additionally converts
 %   sequences to 1D or 2D non-cell arrays if possible.
 %
@@ -16,7 +19,7 @@ function result = load(s, options)
 %       Floating-point number      | double
 %       Integer                    | double
 %       Boolean                    | logical
-%       String                     | string
+%       String                     | string (default) or char
 %       Date (yyyy-mm-ddTHH:MM:SS) | datetime
 %       Date (yyyy-mm-dd)          | datetime
 %       null                       | yaml.Null
@@ -33,6 +36,7 @@ function result = load(s, options)
 
 arguments
     s (1, 1) string
+    options.StringToChar (1, 1) logical = false
     options.ConvertToArray (1, 1) logical = false
 end
 
@@ -62,7 +66,11 @@ end
                     result = yaml.Null;
                 end
             case "char"
-                result = string(node);
+                if options.StringToChar
+                    result = node;
+                else
+                    result = string(node);
+                end
             case "logical"
                 result = logical(node);
             case "java.util.LinkedHashMap"

--- a/+yaml/loadFile.m
+++ b/+yaml/loadFile.m
@@ -3,6 +3,9 @@ function result = loadFile(filePath, options)
 %   DATA = YAML.LOADFILE(FILE) reads a YAML file and converts it to
 %   appropriate data types DATA.
 %
+%   DATA = YAML.LOADFILE(STR, "StringToChar", true) converts YAML String to
+%   MATLAB char instead of MATLAB string.
+%
 %   DATA = YAML.LOADFILE(STR, "ConvertToArray", true) additionally converts
 %   sequences to 1D or 2D non-cell arrays if possible.
 %
@@ -16,7 +19,7 @@ function result = loadFile(filePath, options)
 %       Floating-point number      | double
 %       Integer                    | double
 %       Boolean                    | logical
-%       String                     | string
+%       String                     | string (default) or char
 %       Date (yyyy-mm-ddTHH:MM:SS) | datetime
 %       Date (yyyy-mm-dd)          | datetime
 %       null                       | yaml.Null
@@ -37,10 +40,11 @@ function result = loadFile(filePath, options)
 
 arguments
     filePath (1, 1) string
+    options.StringToChar (1, 1) logical = false
     options.ConvertToArray (1, 1) logical = false
 end
 
 content = string(fileread(filePath));
-result = yaml.load(content, "ConvertToArray", options.ConvertToArray);
+result = yaml.load(content, "ConvertToArray", options.ConvertToArray, "StringToChar", options.StringToChar);
 
 end


### PR DESCRIPTION
### Summary
I added the option **StringToChar** to `load.m` and `loadFile.m`, which lets the user choose if YAML String should be converted to MATLAB string (default, false) or MATLAB char (true).

### Rationale
Depending on the context, MATLAB char are sometimes easier to manipulate than MATLAB string, especially in older versions of MATLAB. Therefore in many of my use cases, I found it useful to have an option to decide what should YAML String be converted to.

I can't imagine any YAML combination where using char would create a bug, because Sequences are converted to cell arrays, and Mappings are converted to struct, which both support char's correctly.

Feel free to change the name of the option or the implementation of the feature!